### PR TITLE
Fix missing default export declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,4 +33,4 @@ interface TrackVisibilityProps {
   partialVisibility?: boolean;
 }
 
-export class TrackVisibility extends React.Component<TrackVisibilityProps> {}
+export default class TrackVisibility extends React.Component<TrackVisibilityProps> {}


### PR DESCRIPTION
Using `react-on-screen` in a TypeScript-based project

```
import TrackVisibility from 'react-on-screen';
```

results in error

```
(2,8): Module '"/path/to/project/node_modules/react-on-screen/index"' has no default export.
```